### PR TITLE
Fixed version check for R versions 3.0 and higher.

### DIFF
--- a/R/install.blk.R
+++ b/R/install.blk.R
@@ -6,10 +6,10 @@ if(x=="osx" | x=="linux"){install.packages("UScensus2010blk", repos="http://laks
 	}
 
 if(x=="windows"){
-	rVer<-as.numeric(R.Version()$minor)
-	
-	if(rVer>=11){
-		install.packages("UScensus2010blk", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
+  rVer<-c(major = as.numeric(R.Version()$major), minor = as.numeric(R.Version()$minor))
+  
+  if(rVer['major'] > 2 || (rVer['major'] == 2 && rVer['minor'] >=11)){
+    install.packages("UScensus2010blk", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
 		return()
 		}else{stop("Not Available Yet")}
 }

--- a/R/install.blkgrp.R
+++ b/R/install.blkgrp.R
@@ -6,10 +6,10 @@ if(x=="osx" | x=="linux"){install.packages("UScensus2010blkgrp", repos="http://l
 	}
 
 if(x=="windows"){
-	rVer<-as.numeric(R.Version()$minor)
-	
-	if(rVer>=11){
-		install.packages("UScensus2010blkgrp", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
+  rVer<-c(major = as.numeric(R.Version()$major), minor = as.numeric(R.Version()$minor))
+  
+  if(rVer['major'] > 2 || (rVer['major'] == 2 && rVer['minor'] >=11)){
+    install.packages("UScensus2010blkgrp", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
 		return()
 		}else{stop("Not Available Yet")}
 }

--- a/R/install.cdp.R
+++ b/R/install.cdp.R
@@ -6,10 +6,10 @@ if(x=="osx" | x=="linux"){install.packages("UScensus2010cdp", repos="http://laks
 	}
 
 if(x=="windows"){
-	rVer<-as.numeric(R.Version()$minor)
-	
-	if(rVer>=11){
-		install.packages("UScensus2010cdp", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
+  rVer<-c(major = as.numeric(R.Version()$major), minor = as.numeric(R.Version()$minor))
+  
+  if(rVer['major'] > 2 || (rVer['major'] == 2 && rVer['minor'] >=11)){
+    install.packages("UScensus2010cdp", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
 		return()
 		}else{stop("Not Available Yet")}
 }

--- a/R/install.county.R
+++ b/R/install.county.R
@@ -6,10 +6,10 @@ if(x=="osx" | x=="linux"){install.packages("UScensus2010county", repos="http://l
 	}
 
 if(x=="windows"){
-	rVer<-as.numeric(R.Version()$minor)
-	
-	if(rVer>=11){
-		install.packages("UScensus2010county", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
+  rVer<-c(major = as.numeric(R.Version()$major), minor = as.numeric(R.Version()$minor))
+  
+  if(rVer['major'] > 2 || (rVer['major'] == 2 && rVer['minor'] >=11)){
+    install.packages("UScensus2010county", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
 		return()
 		}else{stop("Not Available Yet")}
 }

--- a/R/install.tract.R
+++ b/R/install.tract.R
@@ -6,9 +6,9 @@ if(x=="osx" | x=="linux"){install.packages("UScensus2010tract", repos="http://la
 	}
 
 if(x=="windows"){
-	rVer<-as.numeric(R.Version()$minor)
+	rVer<-c(major = as.numeric(R.Version()$major), minor = as.numeric(R.Version()$minor))
 	
-	if(rVer>=11){
+	if(rVer['major'] > 2 || (rVer['major'] == 2 && rVer['minor'] >=11)){
 		install.packages("UScensus2010tract", repos="http://lakshmi.calit2.uci.edu/census2000/R/",type="source")
 		return()
 		}else{stop("Not Available Yet")}


### PR DESCRIPTION
install.tract, install.blk, install.blkgrp, install.county, and install.cdp all need to check for R version >= 2.11 under windows, but they don't check the major version, so they incorrectly report an error for R versions 3.0, 3.1, 3.2, etc. 

This pull request checks for R.Version()$major > 2.
